### PR TITLE
set empty hash for namsepace by default

### DIFF
--- a/lib/embulk/parser/xpath.rb
+++ b/lib/embulk/parser/xpath.rb
@@ -15,7 +15,7 @@ module Embulk
         task = {
           :schema => schema_serialized,
           :root => config.param("root", :string),
-          :namespaces => config.param("namespaces", :hash)
+          :namespaces => config.param("namespaces", :hash, :default => {})
         }
         columns = schema.each_with_index.map do |c, i|
           Column.new(i, c["name"], c["type"].to_sym)


### PR DESCRIPTION
This p-r sets empty hash *{}* to namespace by default.
Sometimes it can be non-required parameter.